### PR TITLE
Add link to Webflow template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The privacy design patterns offered include:
 
 See the technical readme file for developer instructions on how you can deploy these privacy design patterns in your own privacy notice.
 
-If you build your website with Webflow, <a href="https://bearer.sh" target="_blank">Bearer</a>&nbsp;has adapted these deisgn patterns into a <a href="https://webflow.com/website/privacy-policy-template-bearer" target="_blank">free Webflow template</a>&nbsp;you can clone and customise.   
+If you build your website with Webflow, <a href="https://bearer.sh" target="_blank">Bearer</a>&nbsp;has adapted these design patterns into a <a href="https://webflow.com/website/privacy-policy-template-bearer" target="_blank">free Webflow template</a>&nbsp;you can clone and customise.   
 
 <b>IMPORTANT LEGAL STUFF</b> (hence the scary capital letters...)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The privacy design patterns offered include:
 
 See the technical readme file for developer instructions on how you can deploy these privacy design patterns in your own privacy notice.
 
-If you build your website with Webflow, <a href="https://bearer.sh" target="_blank">Bearer</a>&nbsp;has adapted these patterns into a <a href="https://webflow.com/website/privacy-policy-template-bearer" target="_blank">template</a>&nbsp;you can clone and use.   
+If you build your website with Webflow, <a href="https://bearer.sh" target="_blank">Bearer</a>&nbsp;has adapted these deisgn patterns into a <a href="https://webflow.com/website/privacy-policy-template-bearer" target="_blank">free Webflow template</a>&nbsp;you can clone and customise.   
 
 <b>IMPORTANT LEGAL STUFF</b> (hence the scary capital letters...)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The privacy design patterns offered include:
 
 See the technical readme file for developer instructions on how you can deploy these privacy design patterns in your own privacy notice.
 
+If you build your website with Webflow, <a href="https://bearer.sh" target="_blank">Bearer</a>&nbsp;has adapted these patterns into a <a href="https://webflow.com/website/privacy-policy-template-bearer" target="_blank">template</a>&nbsp;you can clone and use.   
+
 <b>IMPORTANT LEGAL STUFF</b> (hence the scary capital letters...)
 
 Subject to the below Juro Online Limited (known as Juro) and Stefania Passera grant you a worldwide, royalty-free, non-exclusive right to use the design patterns in the privacy notice and the code base in this repository. 


### PR DESCRIPTION
We, at Bearer, used your patterns to build our own privacy page with Webflow (https://www.bearer.sh/privacy). Thanks BTW 🙏

We made it freely available to other Webflow users, in the form of a template (https://webflow.com/website/privacy-policy-template-bearer) people can clone and customize.

I added the link to the Webflow template in the README file.